### PR TITLE
 fix the build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
         <repository>
             <id>central</id>


### PR DESCRIPTION

Looks the maven repository url is wrong before:

http://packages.confluent.io/maven/

Should be 
            <url>https://packages.confluent.io/maven/</url>
